### PR TITLE
Converting float64 to int

### DIFF
--- a/examples/rotating_cube.go
+++ b/examples/rotating_cube.go
@@ -124,10 +124,10 @@ func run(projection bool) {
 			}
 
 			for _, f := range faces {
-				c.DrawLine(t[f[0]].x, t[f[0]].y, t[f[1]].x, t[f[1]].y)
-				c.DrawLine(t[f[1]].x, t[f[1]].y, t[f[2]].x, t[f[2]].y)
-				c.DrawLine(t[f[2]].x, t[f[2]].y, t[f[3]].x, t[f[3]].y)
-				c.DrawLine(t[f[3]].x, t[f[3]].y, t[f[0]].x, t[f[0]].y)
+				c.DrawLine(int(t[f[0]].x), int(t[f[0]].y), int(t[f[1]].x), int(t[f[1]].y))
+				c.DrawLine(int(t[f[1]].x), int(t[f[1]].y), int(t[f[2]].x), int(t[f[2]].y))
+				c.DrawLine(int(t[f[2]].x), int(t[f[2]].y), int(t[f[3]].x), int(t[f[3]].y))
+				c.DrawLine(int(t[f[3]].x), int(t[f[3]].y), int(t[f[0]].x), int(t[f[0]].y))
 			}
 
 			f := c.Frame(-40, -40, 80, 80)


### PR DESCRIPTION
Fixes compilation error which seems to be broken since 32d1e2ef80813ba9e88c187ced84f2b04b9a116e


Sidenote: the `rotating_cube` demo displays as red blinking characters in my terminal. Something is likely wrong with escape codes. Maybe the code should move away from `termbox-go` to a newer library.